### PR TITLE
Add key 'l' for logging a task

### DIFF
--- a/cmds.pl
+++ b/cmds.pl
@@ -16,7 +16,25 @@ sub prompt_quit {
 #------------------------------------------------------------------
 
 sub task_add {
-  my $str = &prompt_str("Add: ");
+  &task_cmd_parseable_with_prompt("add", "Add")
+}
+
+#------------------------------------------------------------------
+
+sub task_log {
+  &task_cmd_parseable_with_prompt("log", "Log")
+}
+
+#------------------------------------------------------------------
+
+# General function for invoking task commands with a prompt and
+# where the input provided at the prompt shall be parseable, i.e.,
+# be a sequence of strings. Examples are the commands "add" and
+# "log", while non-examples are "annotate" or "done".
+sub task_cmd_parseable_with_prompt {
+  my $cmd = $_[0];
+  my $prompt = $_[1];
+  my $str = &prompt_str("$prompt: ");
   if ( $str eq '' ) {
     &draw_prompt_line('');
     return;
@@ -24,7 +42,7 @@ sub task_add {
   # TODO: get rid off escaping by replacing the shell call in task_exec() by something like IPC::Open2().
   #       That would allow us to get rid of all shell expansions, quotations and escaping. [BaZo]
   $str =~ s{[&^\\]}{\\\&}g;
-  my ($es,$result) = &task_exec("add $str");
+  my ($es,$result) = &task_exec("$cmd $str");
   if ( $es != 0 ) {
     $error_msg = $result;
     &draw_error_msg();

--- a/commands
+++ b/commands
@@ -2,6 +2,7 @@
  cmd   a STRING        add a new task
  cmd   A STRING        add an annotation to the current task
  cmd   b STRING        start/stop a task
+ cmd   l STRINT        log a new task
  cmd   m STRING        modify the current task
  cmd   :![rw] STRING   execute "STRING" in shell. 'r' rereads, 'w' waits
  cmd   t               prepend the command prompt with ":!rw task "

--- a/getch.pl
+++ b/getch.pl
@@ -113,6 +113,11 @@ sub getch_loop {
         last CASE;
       }
 
+      if ( $ch eq 'l' ) {
+        &task_log();
+        last CASE;
+      }
+
       if ( $ch eq 'L' ) {
         $task_selected_idx = $display_start_idx + $REPORT_LINES - 1;
         if ( $task_selected_idx >= $#report_tokens-1 ) { $task_selected_idx = $#report_tokens; }


### PR DESCRIPTION
This makes "task log" as easily accessible as "task add". Would be nice if this feature could be included in the next version.