### PR TITLE
add "nowait" option to avoid asking for enter after modifications

### DIFF
--- a/exec.pl
+++ b/exec.pl
@@ -27,6 +27,12 @@ sub task_exec {
 
 #------------------------------------------------------------------
 
+sub exited_successfully {
+  my $status = shift || 0;
+  return 1  if  WIFEXITED($status) and WEXITSTATUS($status)==0;
+  return undef;
+}
+
 sub shell_exec {
   my ($cmd,$mode) = @_;
   endwin();
@@ -40,7 +46,14 @@ sub shell_exec {
     exit();
   }
   wait();
-  if ( $mode eq 'wait' ) {
+  my $success = &exited_successfully($?);
+  # two reason to wait:
+  # - an error occurred
+  # - $mode is wait and the user didn't specify nowait in config file
+  if ( not $success or ( $mode eq 'wait' and not $nowait ) ) {
+    if (not $success) {
+      print "Error while executing command `$cmd'\n";
+    }
     print "Press return to continue.\r\n";
     <STDIN>;
   }

--- a/vit.pl
+++ b/vit.pl
@@ -12,7 +12,7 @@ use Curses;
 use Time::HiRes qw(usleep);
 use Try::Tiny;
 use utf8;
-use POSIX qw(setlocale LC_CTYPE);
+use POSIX qw(setlocale LC_CTYPE WIFSIGNALED WIFEXITED WEXITSTATUS);
 use I18N::Langinfo qw(langinfo CODESET);
 use Encode;
 use Text::CharWidth qw(mbswidth);
@@ -106,6 +106,7 @@ our $during_try = 0;
 
 # vitrc settings
 my $burndown = "no";
+my $nowait = undef;
 
 require 'args.pl';
 require 'cmdline.pl';

--- a/vitrc.5
+++ b/vitrc.5
@@ -70,6 +70,12 @@ left corner. It is set to "no" by default because it requires extra time to
 obtain (from running 'task burndown' in the background. This variable was
 essentially set to "yes" for VIT versions 1.2 and below.
 
+.TP
+.B nowait=no
+When set to "yes", VIT will not show output of the task command after
+modifications to a task are made.  By default, vit will show the output of the
+task command and wait for enter.
+
 .SH EXAMPLES
 .SS EXTERNAL COMMANDS
 Note that for many of the examples, you need to have the appropriate extension

--- a/vitrc.pl
+++ b/vitrc.pl
@@ -36,6 +36,14 @@ sub parse_vitrc {
           }
           $burndown = $configval;
         }
+        elsif ($configname eq "nowait") {
+          if (!&sanitycheck_bool($configval)) {
+            print STDERR "ERROR: boolean config variable '$configname' must ".
+                         "be set to 'yes' or 'no'.\n";
+            exit(1);
+          }
+          $nowait = $configval;
+        }
       }
     }
     close(IN);


### PR DESCRIPTION
This fixes #7 