### PR TITLE
Add SIGUSR1 handler that reloads taskwarrior data

### DIFF
--- a/getch.pl
+++ b/getch.pl
@@ -5,8 +5,6 @@ sub getch_loop {
   while (1) {
     my $ch = $report_win->getch();
     &audit("Received key: $ch");
-    $refresh_needed = 0;
-    $reread_needed = 0;
     $error_msg = '';
     $feedback_msg = '';
 
@@ -295,6 +293,8 @@ sub getch_loop {
     $prev_ch = $ch;
     if ( $reread_needed ) { &read_report('refresh'); }
     if ( $refresh_needed || $reread_needed ) { &draw_screen(); }
+    $refresh_needed = 0;
+    $reread_needed = 0;
 
   }
 }

--- a/on-exit.vit
+++ b/on-exit.vit
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+modified=0
+while read modified_task
+do
+	modified=1
+done
+
+if [ $modified -eq 1 ]; then
+	# notify all running vit instances
+	killall -USR1 vit 2> /dev/null || true
+fi

--- a/vit.pl
+++ b/vit.pl
@@ -125,6 +125,11 @@ require 'read.pl';
 require 'screen.pl';
 require 'search.pl';
 
+# Reload report and redraw screen when SIGUSR1 is received. This will only work
+# on curses implementations that interrupt getch() when a signal is received
+# (getch will return -1, which is already handled in getch_loop). 
+$SIG{'USR1'} = sub { $reread_needed = 1; };
+
 ###################################################################
 ## main...
 


### PR DESCRIPTION
Also add taskwarrior on_exit hook that will ensure any running vit instances are notified.

This is a simpler alternative to the patch provided by #151. The idea is that the on_exit.vit script will be manually copied by the user to the ~/.task/hooks directory, and whenever taskwarrior is updated any running vit instances will be refreshed.