### PR TITLE
Please make the build reproducible

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,7 +18,7 @@ build:
 	fi && \
 	cat vit.pl | grep -v ^require \
 	  | sed "s:%prefix%:$(PREFIX):" \
-	  | sed "s/%BUILD%/$(VERSION) built after `date -r CHANGES`/" \
+	  | sed "s/%BUILD%/$(VERSION) built after `date -u -r CHANGES`/" \
 	  | sed "s/%VERSION%/$(VERSION)$${GITHASH}/" \
 	  | sed "s:%TASK%:$(TASK):" \
 	  | sed "s:%CLEAR%:$(CLEAR):" \


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, we noticed that vit could not be built reproducibly.

This is actually a regression from vit 1.2 — unfortunately whilst various changes were merged upstream they appeared to miss `date`'s `--utc` argument resulting in:

    -# 1.3.beta1 built after Mon Aug  6 03:08:23 -12 2018
    +# 1.3.beta1 built after Tue Aug  7 05:08:23 +14 2018