### PR TITLE
Only run task sync if a taskd server is configured

### DIFF
--- a/env.pl
+++ b/env.pl
@@ -54,6 +54,10 @@ sub init_task_env {
       push(@reports, $1);
       next;
     }
+    if ( $_ =~ /taskd\.server\s/ ) {
+      $taskd_server = 1;
+      next;
+    }
     if ( $_ =~ /The color .* is not recognized/ ) {
       endwin();
       print "$_\r\n";

--- a/getch.pl
+++ b/getch.pl
@@ -168,15 +168,10 @@ sub getch_loop {
       }
 
       if ( $ch eq 's' ) {
-        my $majmin = &task_version('major.minor');
-        if ( $majmin >= 2.3 ) {
+        if ( $taskd_server ) {
           &shell_exec("task sync",'wait');
-          $reread_needed = 1;
         }
-        else {
-          $error_msg = "'sync' was introduced in Taskwarrior 2.3.0";
-          $refresh_needed = 1;
-        }
+        $reread_needed = 1;
         last CASE;
       }
 

--- a/vit.pl
+++ b/vit.pl
@@ -82,6 +82,7 @@ our @report2taskid = ();
 our $search_direction = 1;
 our $search_pat = undef;
 our $selection_attrs = '';
+our $taskd_server = 0;
 our @taskid2report = ();
 our $tasks_completed = 0;
 our $tasks_pending = 0;


### PR DESCRIPTION
Allows to reread the tasks using with no taskd server using 's'.