### PR TITLE
Fix empty tasklist

### DIFF
--- a/env.pl
+++ b/env.pl
@@ -20,6 +20,7 @@ sub init_shell_env {
 sub init_task_env {
   my @reports;
   my $id_column = 0;
+  my $empty_report = 0;
   my ($header_color,$task_header_color,$vit_header_color);
   &audit("EXEC $task show 2>&1");
   open(IN,"$task show 2>&1 |");
@@ -94,9 +95,12 @@ sub init_task_env {
       init_pair($COLOR_REPORT_HEADER,$parsed_colors_fg[0],$parsed_colors_bg[0]);
       $id_column = 1;
     }
+    if ( $_ =~ /No matches./ ) {
+      $empty_report = 1;
+    }
   }
   close(IN);
-  if ( ! $id_column && $default_command ne 'summary' ) {
+  if ( ! $empty_report && ! $id_column && $default_command ne 'summary' ) {
     endwin();
     print "Fatal error: default.command (\"$default_command\") must print an \"ID\" column\n";
     exit(1);

--- a/read.pl
+++ b/read.pl
@@ -182,18 +182,25 @@ sub inner_read_report {
     }
   } else {
     $error_msg = "Error: task $current_command: no matches";
-    $current_command = $prev_command;
-    $display_start_idx = $prev_display_start_idx;
-    $task_selected_idx = $prev_task_selected_idx;
-    @report_header_tokens = @prev_report_header_tokens;
-    @report_header_attrs = @prev_report_header_attrs;
-    @report_tokens = @prev_report_tokens;
-    @report_lines = @prev_report_lines;
-    @report_colors_fg = @prev_report_colors_fg;
-    @report_colors_bg = @prev_report_colors_bg;
-    @report_attrs = @prev_report_attrs;
-    @report2taskid = @prev_report2taskid;
-    $convergence = $prev_convergence;
+
+    if ( $show_empty_report eq "yes" ) {
+      @report_header_tokens = ("NO MATCHES");
+    }
+    else {
+      $current_command = $prev_command;
+      $display_start_idx = $prev_display_start_idx;
+      $task_selected_idx = $prev_task_selected_idx;
+      @report_header_tokens = @prev_report_header_tokens;
+      @report_header_attrs = @prev_report_header_attrs;
+      @report_tokens = @prev_report_tokens;
+      @report_lines = @prev_report_lines;
+      @report_colors_fg = @prev_report_colors_fg;
+      @report_colors_bg = @prev_report_colors_bg;
+      @report_attrs = @prev_report_attrs;
+      @report2taskid = @prev_report2taskid;
+      $convergence = $prev_convergence;
+    }
+
     return;
   }
 

--- a/read.pl
+++ b/read.pl
@@ -4,7 +4,7 @@
 sub read_report {
   my ($mode) = @_;
   &inner_read_report($mode);
-  if ( $prev_ch eq 'd' && $error_msg =~ /Error: task .*: no matches/ ) {
+  if ( $error_msg =~ /Error: task .*: no matches/ ) {
     # take care of marking last done...
     &inner_read_report('init');
   }

--- a/vit.pl
+++ b/vit.pl
@@ -107,6 +107,7 @@ our $during_try = 0;
 
 # vitrc settings
 my $burndown = "no";
+my $show_empty_report = "no";
 my $confirmation = 1;
 my $nowait = undef;
 

--- a/vitrc.5
+++ b/vitrc.5
@@ -81,6 +81,13 @@ When set to "no", VIT will not show output of the task command after
 modifications to a task are made.  By default, VIT will show the output of the
 task command and wait for enter.
 
+.TP
+.B show_empty_report=no
+When set to "no" (default), VIT will not show a task report if there are no
+tasks in it. It will show the last non-empty report.
+When set to "yes", VIT will display "NO MATCHES" instead of the table.
+
+
 .SH EXAMPLES
 .SS EXTERNAL COMMANDS
 Note that for many of the examples, you need to have the appropriate extension

--- a/vitrc.pl
+++ b/vitrc.pl
@@ -39,6 +39,15 @@ sub parse_vitrc {
           }
           $burndown = $configval;
         }
+        if ($configname eq "show_empty_report") {
+          # TODO: fix code duplication (see below)
+          if (!&sanitycheck_bool($configval)) {
+            print STDERR "ERROR: boolean config variable '$configname' must ".
+                         "be set to 'yes' or 'no'.\n";
+            exit(1);
+          }
+          $show_empty_report = $configval;
+        }
         elsif ($configname eq "confirmation") {
           # TODO: fix code duplication (see above)
           if (!&sanitycheck_bool($configval)) {


### PR DESCRIPTION
Starting vit without any tasks leads to an annoying error message:

    Fatal error: default.command ("next") must print an "ID" column

The first commit ignores that the columns are missing if the task command outputs `No matches`.
The second commit adds an option to update the task list, even if there are no tasks in the report.