### PR TITLE
improve escaping of special characters when adding tasks

### DIFF
--- a/cmds.pl
+++ b/cmds.pl
@@ -19,14 +19,16 @@ sub prompt_quit {
 
 sub task_add {
   my $str = &prompt_str("Add: ");
-  if ( $str eq '' ) {
+  if ( $str =~ /^ *$/ ) {
     &draw_prompt_line('');
     return;
   }
   # TODO: get rid off escaping by replacing the shell call in task_exec() by something like IPC::Open2().
   #       That would allow us to get rid of all shell expansions, quotations and escaping. [BaZo]
-  $str =~ s{[&^\\]}{\\\&}g;
-  my ($es,$result) = &task_exec("add $str");
+  # escape special characters, adapted from https://unix.stackexchange.com/a/418869/153926
+  $str =~ s{[\002-\011\013-\032\\\(\)\^\*\<\=\>\~ \!\202-\377]}{\\$&}go;
+  $str =~ s{[\']}{'"'"'}go;
+  my ($es,$result) = &task_exec("add '$str'");
   if ( $es != 0 ) {
     $error_msg = $result;
     &draw_error_msg();

--- a/cmds.pl
+++ b/cmds.pl
@@ -26,9 +26,9 @@ sub task_add {
   # TODO: get rid off escaping by replacing the shell call in task_exec() by something like IPC::Open2().
   #       That would allow us to get rid of all shell expansions, quotations and escaping. [BaZo]
   # escape special characters, adapted from https://unix.stackexchange.com/a/418869/153926
-  $str =~ s{[\002-\011\013-\032\\\(\)\^\*\<\=\>\~ \!\202-\377]}{\\$&}go;
+  $str =~ s{[\002-\011\013-\032\\\#\?\`\(\)\{\}\[\]\^\*\<\=\>\~\|\;\"\!\$\&\'\202-\377]}{\\$&}go;
   $str =~ s{[\']}{'"'"'}go;
-  my ($es,$result) = &task_exec("add '$str'");
+  my ($es,$result) = &task_exec("add $str");
   if ( $es != 0 ) {
     $error_msg = $result;
     &draw_error_msg();


### PR DESCRIPTION
This commit improves escaping when adding a task.
Most notably, adding task descriptions with parenthesis is now supported.