### PR TITLE
remove hard-coded perl path

### DIFF
--- a/configure
+++ b/configure
@@ -1771,11 +1771,6 @@ fi
 if test "$PERL" = "NOT_FOUND"; then
   as_fn_error $? "can not continue: perl not found" "$LINENO" 5
 fi
-if test "$PERL" != "/usr/bin/perl"; then
-  echo configure: error: can not continue... perl must be installed as /usr/bin/perl
-  echo confgiure: hint: try \"sudo ln -s $PERL /usr/bin/perl\"
-  exit 1
-fi
 
 PERL_MODULE_CHECK=`perl -e "use Curses" 2> /dev/null; echo $?`
 if test "$PERL_MODULE_CHECK" = "2"; then

--- a/vit.pl
+++ b/vit.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # VIT - Visual Interactive Taskwarrior
 #
@@ -8,6 +8,7 @@
 # Copyright 2013 - 2018, Scott Kostyshak
 
 use strict;
+use warnings;
 use Curses;
 use Time::HiRes qw(usleep);
 use Try::Tiny;


### PR DESCRIPTION
This removes the hard-coded /usr/bin/perl from the shebang
line, in favor of a /usr/bin/env approach, which allows for
non-standard Perl locations, such as /usr/local/bin/perl
(a requirement for building on OS X).

Since /usr/bin/env argument parsing isn't portable, the -w
argument in the shebang line is removed in favor of
'use warnings', which is the recommended approach given at
https://perldoc.perl.org/warnings.html

Tested as working on Ubuntu and OS X